### PR TITLE
Small typo and syntax fixes for English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Requirements will be more precise in the future based on feedback and code optim
 # Uninstalling
 
 You can uninstall by simply deleting the `d912pxy` folder, `bin64/d3d9.dll` and `bin64/P7x64.dll`.
-Don't remove any other files other then that.
+Don't remove any other files other than that.
 
 # Known bugs
 
--Screenshot functionality not working
+- Screenshot functionality not working
 
 # Troubleshooting
 
@@ -82,24 +82,24 @@ Don't remove any other files other then that.
 
   Do not ask game support about this crashes!
   
-  If you game crashes without d912pxy, don't ask about this here, cause d912pxy do zero modifications to game data.
+  If you game crashes without d912pxy, don't ask about this here, because d912pxy do zero modification to game data.
   
-  Be shure that game runs without d912pxy!
+  Be sure that the game runs without d912pxy!
   
-  Next update your driver and directx9.
+  Next, update your driver and directx9.
   
-  (link to dx9 https://www.microsoft.com/ru-ru/download/details.aspx?id=34429)
+  (link to dx9 https://www.microsoft.com/en-us/download/details.aspx?id=34429)
   
-  Then, if you still here, post your issue on github with 
+  Then, if you are still here, post your issue on github with 
   
     1. Log file form P7logs
     2. Crash.dmp and d912pxy_crash.txt if you have it    
     
- If you asked to run debug version do this
+ If you are asked to run debug version do this
  
    0. Debug version writes ton of data, do not run it for long time!
-   1. Install Release_d  version [from here](https://github.com/megai2/d912pxy/releases).
-   2. Run game, reproduce situation.
+   1. Install Release_d version [from here](https://github.com/megai2/d912pxy/releases)
+   2. Run the game and reproduce the error
    3. Send the log file or/and Crash.dmp to github
 
 ## Case 3 
@@ -108,12 +108,12 @@ Don't remove any other files other then that.
  
 **Solution**
 
-  1. Install Release_ps version [from here](https://github.com/megai2/d912pxy/releases).
-  2. Run the game, reproduce visual error.
-  3. Exit game, remove d912pxy/pck/shaders_cso.pck
-  4. Install regular version.
-  5. Run the game again. Wait for shaders to recompile, as this will take notable time.
-  6. If error is not fixed, post your issue on github with a description on how to reproduse visual error.
+  1. Install Release_ps version [from here](https://github.com/megai2/d912pxy/releases)
+  2. Run the game and reproduce visual error
+  3. Exit the game and remove d912pxy/pck/shaders_cso.pck
+  4. Install the regular version
+  5. Run the game again and wait for the shaders to recompile (this will take a notable time)
+  6. If the error is not fixed, post your issue on github with a description on how to reproduse the visual error.
 
 # Support developer
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is in early development, expect bugs, crashes, hangs, stalls and al
 Profiling shows that API overhead for d912pxy is up to 70% less then for plain DirectX9.
 Real performance differs on scene and on hardware.
 
-Like running mistlock sanctuary in Guild Wars 2 on i7-7700/GTX960 results in:
+For example, running mistlock sanctuary in Guild Wars 2 on i7-7700/GTX960 results in:
 
 ```
 @6.3k batches, all max, 1080p
@@ -44,7 +44,7 @@ https://cdn.discordapp.com/attachments/477036595019644928/524541036626837504/unk
 You will obviously need a DirectX12 capable GPU, with 12.1 feature level and 3GB+ VRAM.
 16 GB of RAM is recommended.
 
-Requirements will be more precise in the future based on feedback and code optimization.
+Requirements will become more precise in the future based on feedback and code optimization.
 
 # Installing
 
@@ -80,7 +80,7 @@ Don't remove any other files other than that.
   
 **Solution**
 
-  Do not ask game support about this crashes!
+  Do not ask game support about these crashes!
   
   If your game crashes without d912pxy don't ask about this here because d912pxy does zero modification to the game data.
   
@@ -109,11 +109,11 @@ Don't remove any other files other than that.
 **Solution**
 
   1. Install Release_ps version [from here](https://github.com/megai2/d912pxy/releases)
-  2. Run the game and reproduce visual error
+  2. Run the game and reproduce the visual error
   3. Exit the game and remove d912pxy/pck/shaders_cso.pck
   4. Install the regular version
   5. Run the game again and wait for the shaders to recompile (this will take a notable time)
-  6. If the error is not fixed, post your issue on github with a description on how to reproduse the visual error.
+  6. If the error is not fixed post your issue on github with a description on how to reproduse the visual error
 
 # Support developer
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Don't remove any other files other than that.
 
   Do not ask game support about this crashes!
   
-  If you game crashes without d912pxy, don't ask about this here, because d912pxy do zero modification to game data.
+  If your game crashes without d912pxy don't ask about this here because d912pxy does zero modification to the game data.
   
-  Be sure that the game runs without d912pxy!
+  Make sure that the game runs without d912pxy!
   
   Next, update your driver and directx9.
   


### PR DESCRIPTION
Fixed a few typos, syntax and layout minor issues I spotted in the English README. I also modifed the link to Dx9 so that it goes to the English version of the page instead of the Russian one on this README.