### PR TITLE
Fixes and improvements for the ImGui overlay

### DIFF
--- a/d912pxy/d912pxy_config.h
+++ b/d912pxy/d912pxy_config.h
@@ -90,12 +90,12 @@ typedef enum d912pxy_config_value {
 	PXY_CFG_EXTRAS_SHOW_TIMINGS,
 	PXY_CFG_EXTRAS_SHOW_PSO_COMPILE_QUE,
 	PXY_CFG_EXTRAS_SHOW_GC_QUE,
-	PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR,
 	PXY_CFG_EXTRAS_OVERLAY_TOGGLE_KEY,
 	PXY_CFG_EXTRAS_FPS_GRAPH_MAX,
 	PXY_CFG_EXTRAS_FPS_GRAPH_MIN,
 	PXY_CFG_EXTRAS_FPS_GRAPH_W,
 	PXY_CFG_EXTRAS_FPS_GRAPH_H,
+	PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR,
 	PXY_CFG_CNT
 } d912pxy_config_value;
 
@@ -203,12 +203,12 @@ private:
 		{L"extras", L"show_timings", L"0"},//PXY_CFG_EXTRAS_SHOW_TIMINGS,
 		{L"extras", L"show_pso_compile_que", L"0"},//PXY_CFG_EXTRAS_SHOW_PSO_COMPILE_QUE,
 		{L"extras", L"show_gc_que", L"0"},//PXY_CFG_EXTRAS_SHOW_GC_QUE,
-		{L"extras", L"enable_config_editor",L"0"},//PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR
 		{L"extras", L"overlay_toggle_key", L"78"},//PXY_CFG_EXTRAS_OVERLAY_TOGGLE_KEY
 		{L"extras", L"fps_graph_max", L"80"},//PXY_CFG_EXTRAS_FPS_GRAPH_MAX
 		{L"extras", L"fps_graph_min", L"0"},//PXY_CFG_EXTRAS_FPS_GRAPH_MIN
 		{L"extras", L"fps_graph_w", L"512"},//PXY_CFG_EXTRAS_FPS_GRAPH_W
-		{L"extras", L"fps_graph_h", L"256"}//PXY_CFG_EXTRAS_FPS_GRAPH_H
+		{L"extras", L"fps_graph_h", L"256"},//PXY_CFG_EXTRAS_FPS_GRAPH_H
+		{L"extras", L"enable_config_editor",L"0"}//PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR
 		
 	};
 

--- a/d912pxy/d912pxy_config.h
+++ b/d912pxy/d912pxy_config.h
@@ -90,12 +90,12 @@ typedef enum d912pxy_config_value {
 	PXY_CFG_EXTRAS_SHOW_TIMINGS,
 	PXY_CFG_EXTRAS_SHOW_PSO_COMPILE_QUE,
 	PXY_CFG_EXTRAS_SHOW_GC_QUE,
+	PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR,
 	PXY_CFG_EXTRAS_OVERLAY_TOGGLE_KEY,
 	PXY_CFG_EXTRAS_FPS_GRAPH_MAX,
 	PXY_CFG_EXTRAS_FPS_GRAPH_MIN,
 	PXY_CFG_EXTRAS_FPS_GRAPH_W,
 	PXY_CFG_EXTRAS_FPS_GRAPH_H,
-	PXY_CFG_EXTRAS_CONFIG_EDITOR,
 	PXY_CFG_CNT
 } d912pxy_config_value;
 
@@ -203,12 +203,13 @@ private:
 		{L"extras", L"show_timings", L"0"},//PXY_CFG_EXTRAS_SHOW_TIMINGS,
 		{L"extras", L"show_pso_compile_que", L"0"},//PXY_CFG_EXTRAS_SHOW_PSO_COMPILE_QUE,
 		{L"extras", L"show_gc_que", L"0"},//PXY_CFG_EXTRAS_SHOW_GC_QUE,
+		{L"extras", L"enable_config_editor",L"0"},//PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR
 		{L"extras", L"overlay_toggle_key", L"78"},//PXY_CFG_EXTRAS_OVERLAY_TOGGLE_KEY
 		{L"extras", L"fps_graph_max", L"80"},//PXY_CFG_EXTRAS_FPS_GRAPH_MAX
 		{L"extras", L"fps_graph_min", L"0"},//PXY_CFG_EXTRAS_FPS_GRAPH_MIN
 		{L"extras", L"fps_graph_w", L"512"},//PXY_CFG_EXTRAS_FPS_GRAPH_W
-		{L"extras", L"fps_graph_h", L"256"},//PXY_CFG_EXTRAS_FPS_GRAPH_H
-		{L"extras", L"enable_config_editor",L"0"}//PXY_CFG_EXTRAS_CONFIG_EDITOR
+		{L"extras", L"fps_graph_h", L"256"}//PXY_CFG_EXTRAS_FPS_GRAPH_H
+		
 	};
 
 };

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -278,12 +278,35 @@ void d912pxy_extras::OnHotkeyTriggered()
 	overlayShowMode = (overlayShowMode + 1) % eoverlay_modes_count;
 }
 
+UINT32 d912pxy_extras::GetOverlayWindowFlags(bool isMain = false) {
+
+	UINT32 mainWindowFlags = (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs);
+	UINT32 childWindowFlags = ImGuiWindowFlags_None;
+	UINT32 standaloneWindowFlags = (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs);
+
+	if (isMain)
+		return mainWindowFlags;
+
+	if (bShowMainWindow)
+		return childWindowFlags;
+
+	return standaloneWindowFlags;			
+}
+
+bool* d912pxy_extras::GetOverlayWindowCloseable(bool* WindowRenderBool = nullptr) {
+
+	if (bShowMainWindow && WindowRenderBool)
+		return WindowRenderBool;
+
+	return nullptr;
+
+}
+
 void d912pxy_extras::DrawConfigEditor() 
 {
+	
 	ImGui::SetNextWindowSize(ImVec2(475, 600));
-	ImGui::Begin("d912pxy config editor",
-				(bShowMainWindow == false) ? nullptr : &bShowConfigEditor,
-				(overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs));
+	ImGui::Begin("d912pxy config editor", GetOverlayWindowCloseable(&bShowConfigEditor), GetOverlayWindowFlags());
 	
 	for (int configIndex = 0; configIndex != PXY_CFG_CNT; ++configIndex)
 	{
@@ -340,7 +363,7 @@ void d912pxy_extras::DrawConfigEditor()
 
 void d912pxy_extras::DrawMainWindow()
 {
-	ImGui::Begin(BUILD_VERSION_NAME, nullptr, (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs));
+	ImGui::Begin(BUILD_VERSION_NAME, GetOverlayWindowCloseable(), GetOverlayWindowFlags(true));
 
 	if (bShowFps)
 		ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -262,7 +262,7 @@ void d912pxy_extras::OnHotkeyTriggered()
 
 void d912pxy_extras::DrawConfigEditor() 
 {
-	ImGui::Begin("d912pxy config editor", &bShowConfigEditor);
+	ImGui::Begin("d912pxy config editor", &bShowConfigEditor, ImVec2(475, 600));
 	
 	for (int configIndex = 0; configIndex != PXY_CFG_CNT; ++configIndex)
 	{

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -281,7 +281,9 @@ void d912pxy_extras::OnHotkeyTriggered()
 void d912pxy_extras::DrawConfigEditor() 
 {
 	ImGui::SetNextWindowSize(ImVec2(475, 600));
-	ImGui::Begin("d912pxy config editor", &bShowConfigEditor, (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs));
+	ImGui::Begin("d912pxy config editor",
+				(bShowMainWindow == false) && (bEnableConfigEditor == true) ? nullptr : &bShowConfigEditor,
+				(overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs));
 	
 	for (int configIndex = 0; configIndex != PXY_CFG_CNT; ++configIndex)
 	{

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -278,28 +278,17 @@ void d912pxy_extras::OnHotkeyTriggered()
 	overlayShowMode = (overlayShowMode + 1) % eoverlay_modes_count;
 }
 
-UINT32 d912pxy_extras::GetOverlayWindowFlags(bool isMain = false) {
-
-	UINT32 mainWindowFlags = (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs);
-	UINT32 childWindowFlags = ImGuiWindowFlags_None;
-	UINT32 standaloneWindowFlags = (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs);
-
-	if (isMain)
-		return mainWindowFlags;
-
-	if (bShowMainWindow)
-		return childWindowFlags;
-
-	return standaloneWindowFlags;			
+UINT32 d912pxy_extras::GetOverlayWindowFlags() 
+{
+	return (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs);
 }
 
-bool* d912pxy_extras::GetOverlayWindowCloseable(bool* WindowRenderBool = nullptr) {
-
+bool* d912pxy_extras::GetOverlayWindowCloseable(bool* WindowRenderBool = nullptr) 
+{
 	if (bShowMainWindow && WindowRenderBool)
 		return WindowRenderBool;
 
 	return nullptr;
-
 }
 
 void d912pxy_extras::DrawConfigEditor() 
@@ -363,7 +352,7 @@ void d912pxy_extras::DrawConfigEditor()
 
 void d912pxy_extras::DrawMainWindow()
 {
-	ImGui::Begin(BUILD_VERSION_NAME, GetOverlayWindowCloseable(), GetOverlayWindowFlags(true));
+	ImGui::Begin(BUILD_VERSION_NAME, GetOverlayWindowCloseable(), GetOverlayWindowFlags());
 
 	if (bShowFps)
 		ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -286,7 +286,7 @@ void d912pxy_extras::DrawConfigEditor()
 			
 		//Render InputText box for newValues
 		ImGui::PushID(configIndex);
-		ImGui::PushItemWidth(-200);
+		ImGui::PushItemWidth(-1);
 		ImGui::InputText("##On", iter->newValue, 254);
 		ImGui::PopItemWidth();
 		ImGui::PopID();

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -280,7 +280,8 @@ void d912pxy_extras::OnHotkeyTriggered()
 
 void d912pxy_extras::DrawConfigEditor() 
 {
-	ImGui::Begin("d912pxy config editor", &bShowConfigEditor, ImVec2(475, 600));
+	ImGui::SetNextWindowSize(ImVec2(475, 600));
+	ImGui::Begin("d912pxy config editor", &bShowConfigEditor, (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs));
 	
 	for (int configIndex = 0; configIndex != PXY_CFG_CNT; ++configIndex)
 	{

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -282,7 +282,7 @@ void d912pxy_extras::DrawConfigEditor()
 {
 	ImGui::SetNextWindowSize(ImVec2(475, 600));
 	ImGui::Begin("d912pxy config editor",
-				(bShowMainWindow == false) && (bEnableConfigEditor == true) ? nullptr : &bShowConfigEditor,
+				(bShowMainWindow == false) ? nullptr : &bShowConfigEditor,
 				(overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs));
 	
 	for (int configIndex = 0; configIndex != PXY_CFG_CNT; ++configIndex)

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -58,7 +58,7 @@ void d912pxy_extras::Init()
 	bShowFps = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_FPS);
 	bShowDrawCount = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_DRAW_COUNT);
 	bShowFpsGraph = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_FPS_GRAPH);
-	bEnableConfigEditor = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_CONFIG_EDITOR);
+	bEnableConfigEditor = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR);
 
 	if (bShowFpsGraph)
 	{

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -25,9 +25,11 @@ SOFTWARE.
 #include "stdafx.h"
 
 d912pxy_extras::d912pxy_extras() : 
-	overlayShowMode(eoverlay_hide),
+	overlayShowMode(eoverlay_show),
 	hkDetected(false),
-	gameActive(true)
+	gameActive(true),
+	bShowMainWindow(false),
+	bShowConfigEditor(false)
 {
 	
 }
@@ -87,12 +89,16 @@ void d912pxy_extras::Init()
 	{
 		d912pxy_config_value_dsc* iter = d912pxy_s.config.GetEntryRaw(d912pxy_config_value(configIndex));
 
-		if ((wcsstr(iter->name, L"enable_") || wcsstr(iter->name, L"show_")) && (wcscmp(iter->value,L"0") != 0))
+		if ( wcsstr(iter->name, L"show_") && (wcscmp(iter->value,L"0") != 0))
 		{
-			overlayShowMode = eoverlay_show;
+			bShowMainWindow = true;
 			break;
 		}
 	}
+
+	//Sets Config Editor window to visible if enabled when there's no need for the main window
+	if ((bShowMainWindow == false) && (bEnableConfigEditor == true))
+		bShowConfigEditor = true;
 
 	//imgui setup
 
@@ -329,10 +335,8 @@ void d912pxy_extras::DrawConfigEditor()
 	ImGui::End();
 }
 
-void d912pxy_extras::DrawOverlay()
+void d912pxy_extras::DrawMainWindow()
 {
-	ImGUI_Render_Start();
-
 	ImGui::Begin(BUILD_VERSION_NAME, nullptr, (overlayShowMode != eoverlay_edit) * (ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs));
 
 	if (bShowFps)
@@ -367,6 +371,14 @@ void d912pxy_extras::DrawOverlay()
 	}
 
 	ImGui::End();
+}
+
+void d912pxy_extras::DrawOverlay()
+{
+	ImGUI_Render_Start();
+
+	if (bShowMainWindow)
+		DrawMainWindow();
 
 	if (bShowConfigEditor)
 		DrawConfigEditor();

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -25,7 +25,7 @@ SOFTWARE.
 #include "stdafx.h"
 
 d912pxy_extras::d912pxy_extras() : 
-	overlayShowMode(eoverlay_show),
+	overlayShowMode(eoverlay_hide),
 	hkDetected(false),
 	gameActive(true)
 {
@@ -80,6 +80,18 @@ void d912pxy_extras::Init()
 	{
 		d912pxy_s.config.InitNewValueBuffers();
 		d912pxy_s.config.ValueToNewValueBuffers();
+	}
+
+	//Check if overlay window should be visible on launch based on active config values
+	for (int configIndex = PXY_CFG_EXTRAS_ENABLE; configIndex != PXY_CFG_CNT; configIndex++)
+	{
+		d912pxy_config_value_dsc* iter = d912pxy_s.config.GetEntryRaw(d912pxy_config_value(configIndex));
+
+		if ((wcsstr(iter->name, L"enable_") || wcsstr(iter->name, L"show_")) && (wcscmp(iter->value,L"0") != 0))
+		{
+			overlayShowMode = eoverlay_show;
+			break;
+		}
 	}
 
 	//imgui setup

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -57,10 +57,9 @@ void d912pxy_extras::Init()
 
 	//load config
 	
-	bShowFps = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_FPS);
-	bShowDrawCount = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_DRAW_COUNT);
-	bShowFpsGraph = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_FPS_GRAPH);
-	bEnableConfigEditor = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR);
+	bShowFps = d912pxy_s.config.GetValueB(PXY_CFG_EXTRAS_SHOW_FPS);
+	bShowDrawCount = d912pxy_s.config.GetValueB(PXY_CFG_EXTRAS_SHOW_DRAW_COUNT);
+	bShowFpsGraph = d912pxy_s.config.GetValueB(PXY_CFG_EXTRAS_SHOW_FPS_GRAPH);
 
 	if (bShowFpsGraph)
 	{
@@ -71,10 +70,11 @@ void d912pxy_extras::Init()
 		fpsGraph.min = (float)d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_FPS_GRAPH_MIN);
 	}
 
-	bShowTimings = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_TIMINGS);
-	bShowPSOCompileQue = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_PSO_COMPILE_QUE);
-	bShowGCQue = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_SHOW_GC_QUE);
-	bShowConfigEditor = false;
+	bShowTimings = d912pxy_s.config.GetValueB(PXY_CFG_EXTRAS_SHOW_TIMINGS);
+	bShowPSOCompileQue = d912pxy_s.config.GetValueB(PXY_CFG_EXTRAS_SHOW_PSO_COMPILE_QUE);
+	bShowGCQue = d912pxy_s.config.GetValueB(PXY_CFG_EXTRAS_SHOW_GC_QUE);
+	bEnableConfigEditor = d912pxy_s.config.GetValueB(PXY_CFG_EXTRAS_ENABLE_CONFIG_EDITOR);
+
 
 	hkVKeyCode = d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_OVERLAY_TOGGLE_KEY);
 

--- a/d912pxy/d912pxy_extras.h
+++ b/d912pxy/d912pxy_extras.h
@@ -51,12 +51,12 @@ private:
 	void DrawConfigEditor();
 
 	//config state
-	UINT32 bShowFps;
-	UINT32 bShowDrawCount;
-	UINT32 bShowFpsGraph;
-	UINT32 bShowTimings;
-	UINT32 bShowPSOCompileQue;
-	UINT32 bShowGCQue;
+	bool bShowFps;
+	bool bShowDrawCount;
+	bool bShowFpsGraph;
+	bool bShowTimings;
+	bool bShowPSOCompileQue;
+	bool bShowGCQue;
 
 	//gpu exec + sync time
 	Stopwatch syncNexecTime;
@@ -82,8 +82,8 @@ private:
 	} fpsGraph;
 
 	//Config Editor
-	UINT32 bEnableConfigEditor;
-	UINT32 bShowConfigEditorRestartMsg;
+	bool bEnableConfigEditor;
+	bool bShowConfigEditorRestartMsg;
 
 	//overlay toggle controls
 	enum overlayShowModeValues {

--- a/d912pxy/d912pxy_extras.h
+++ b/d912pxy/d912pxy_extras.h
@@ -47,10 +47,10 @@ private:
 	void ImGUI_Render_End();
 	void OnHotkeyTriggered();
 	void DrawOverlay();
+	void DrawMainWindow();
 	void DrawConfigEditor();
 
 	//config state
-
 	UINT32 bShowFps;
 	UINT32 bShowDrawCount;
 	UINT32 bShowFpsGraph;
@@ -82,9 +82,8 @@ private:
 	} fpsGraph;
 
 	//Config Editor
-	bool bEnableConfigEditor;
-	bool bShowConfigEditorRestartMsg = false;
-	bool bShowConfigEditor;
+	UINT32 bEnableConfigEditor;
+	UINT32 bShowConfigEditorRestartMsg;
 
 	//overlay toggle controls
 	enum overlayShowModeValues {
@@ -93,6 +92,10 @@ private:
 		eoverlay_edit = 2,
 		eoverlay_modes_count = 3
 	};
+
+	//Window Render Booleans
+	bool bShowMainWindow;
+	bool bShowConfigEditor;
 
 	UINT overlayShowMode;
 	bool hkDetected;

--- a/d912pxy/d912pxy_extras.h
+++ b/d912pxy/d912pxy_extras.h
@@ -52,7 +52,7 @@ private:
 
 	//Overlay Window Auto-Setup
 	bool* GetOverlayWindowCloseable(bool* WindowRenderBool);
-	UINT32 GetOverlayWindowFlags(bool isMain);
+	UINT32 GetOverlayWindowFlags();
 
 	//Window Render Booleans
 	bool bShowMainWindow;

--- a/d912pxy/d912pxy_extras.h
+++ b/d912pxy/d912pxy_extras.h
@@ -50,6 +50,14 @@ private:
 	void DrawMainWindow();
 	void DrawConfigEditor();
 
+	//Overlay Window Auto-Setup
+	bool* GetOverlayWindowCloseable(bool* WindowRenderBool);
+	UINT32 GetOverlayWindowFlags(bool isMain);
+
+	//Window Render Booleans
+	bool bShowMainWindow;
+	bool bShowConfigEditor;
+
 	//config state
 	bool bShowFps;
 	bool bShowDrawCount;
@@ -92,10 +100,6 @@ private:
 		eoverlay_edit = 2,
 		eoverlay_modes_count = 3
 	};
-
-	//Window Render Booleans
-	bool bShowMainWindow;
-	bool bShowConfigEditor;
 
 	UINT overlayShowMode;
 	bool hkDetected;


### PR DESCRIPTION
- A default config editor window size has been added and a change to the spacing after the input field has been made. This removes the need to resize the window when opening it for the first time and makes it so that the window doesn't have to be set to an unecessary large width.

- Changed the enum name field of the Config Editor to be the same as the config line entry.

- Fixed #237  by putting the main window in a function behind a bool. The main window is rendered if any of it's "show" components are active. Along with this fix the possibility of the user acessing the config editor when the main window doesn't have to be rendered was added. Also attached to this change, the same conditional window flags from the main window were put on the config editor window