### PR TITLE
Add config key to have extras overlay be hidden by default

### DIFF
--- a/d912pxy/d912pxy_config.h
+++ b/d912pxy/d912pxy_config.h
@@ -88,6 +88,7 @@ typedef enum d912pxy_config_value {
 	PXY_CFG_VFS_PACK_DATA,
 	PXY_CFG_VFS_WRITE_MASK,
 	PXY_CFG_EXTRAS_ENABLE,
+	PXY_CFG_EXTRAS_HIDDEN_ON_LAUNCH,
 	PXY_CFG_EXTRAS_FPS_LIMIT,
 	PXY_CFG_EXTRAS_FPS_LIMIT_INACTIVE,
 	PXY_CFG_EXTRAS_SHOW_FPS,
@@ -275,6 +276,7 @@ private:
 		{L"vfs", L"pack_data", L"0"},//PXY_CFG_VFS_PACK_DATA
 		{L"vfs", L"write_mask", L"0"},//PXY_CFG_VFS_WRITE_MASK
 		{L"extras", L"enable", L"1"},//PXY_CFG_EXTRAS_ENABLE
+		{L"extras", L"hidden_on_launch", L"0"},//PXY_CFG_EXTRAS_HIDDEN_ON_LAUNCH
 		{L"extras", L"fps_limit", L"0"},//PXY_CFG_EXTRAS_FPS_LIMIT,
 		{L"extras", L"fps_limit_inactive", L"0"},//PXY_CFG_EXTRAS_FPS_LIMIT_INACTIVE,
 		{L"extras", L"show_fps", L"1"},//PXY_CFG_EXTRAS_SHOW_FPS,

--- a/d912pxy/d912pxy_extras.cpp
+++ b/d912pxy/d912pxy_extras.cpp
@@ -44,6 +44,8 @@ void d912pxy_extras::Init()
 {
 	NonCom_Init(L"extras");
 
+	if (d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_HIDDEN_ON_LAUNCH)) overlayShowMode = eoverlay_hide;
+
 	activeTargetFrameTime = d912pxy_helper::SafeDiv(1000, d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_FPS_LIMIT));
 	inactiveTargetFrameTime = d912pxy_helper::SafeDiv(1000, d912pxy_s.config.GetValueUI32(PXY_CFG_EXTRAS_FPS_LIMIT_INACTIVE));
 


### PR DESCRIPTION
Adds an additional config key "hidden_on_launch". Causes the extras overlay to be initialized in a hidden state which remains toggleable using the defined hotkey (default Ctrl + Shift + N) as usual.

At present, you would always need to manually toggle / hide the extras overlay after launch if you wish to be able to unhide it at a later point in time. 